### PR TITLE
Remove default values for dockerhub secret

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,5 +3,5 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: "maplarge"

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 
@@ -99,10 +99,10 @@ $ helm install maplarge maplarge -f custom.values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dockerCredentials.email | string | `"dockerhub@emailaddress.com"` | The email associated with the user to pull the image from the private registry |
-| dockerCredentials.password | string | `"dockerhubpassword"` | The password used to pull the image from a private registry |
-| dockerCredentials.registry | string | `"docker.io"` | The docker registry where the associated user exists |
-| dockerCredentials.username | string | `"dockerhubusername"` | The username used to pull the image from a private registry |
+| dockerCredentials.email | string | `nil` | The email associated with the user to pull the image from the private registry |
+| dockerCredentials.password | string | `nil` | The password used to pull the image from a private registry |
+| dockerCredentials.registry | string | `nil` | The docker registry where the associated user exists |
+| dockerCredentials.username | string | `nil` | The username used to pull the image from a private registry |
 
 ### Image Information
 

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -234,16 +234,16 @@ securityContext: {}
 dockerCredentials:
   # -- The docker registry where the associated user exists
   # @section -- Docker configurations
-  registry: docker.io
+  registry:
   # -- The username used to pull the image from a private registry
   # @section -- Docker configurations
-  username: dockerhubusername
+  username:
   # -- The password used to pull the image from a private registry
   # @section -- Docker configurations
-  password: dockerhubpassword
+  password:
   # -- The email associated with the user to pull the image from the private registry
   # @section -- Docker configurations
-  email: dockerhub@emailaddress.com
+  email:
 
 
 # This configuration allows the pod ten seconds to sixty minutes to become ready on startup.


### PR DESCRIPTION
Having these values means we will also create the secret, even if not used