### PR TITLE
Forces a check of notebook envvars before templating and sets a default array 

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,5 +3,5 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.2.3
+version: 3.2.4
 appVersion: "maplarge"

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.2.3](https://img.shields.io/badge/Version-3.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.2.4](https://img.shields.io/badge/Version-3.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 
@@ -148,6 +148,7 @@ $ helm install maplarge maplarge -f custom.values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | notebooks.enabled | bool | `false` | Enables MapLarge Notebooks and creates the necessary Service Account, Role and RoleBinding |
+| notebooks.environmentVariables | list | `[]` | A list of environment variables that may need to be added to MapLarge for a Notebook deployment |
 | notebooks.jsjs | object | `{"value":"ml.config.enableProjects = true;\nml.config.enableNotebooks = true;\n"}` | A list of Notebook specific js.js configurations to add to the default js.js |
 
 ### Deployment Resources

--- a/charts/maplarge/templates/statefulset.yaml
+++ b/charts/maplarge/templates/statefulset.yaml
@@ -130,7 +130,7 @@ spec:
           {{- if .Values.extraEnvironmentVariables }}
           {{- (toYaml .Values.extraEnvironmentVariables | nindent 10) }}
           {{- end }}
-          {{- if .Values.notebooks.enabled }}
+          {{- if and .Values.notebooks.enabled .Values.notebooks.environmentVariables }}
           {{- (toYaml .Values.notebooks.environmentVariables | nindent 10) }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -233,7 +233,7 @@ securityContext: {}
 # -- this will create your pull secret for you. Required fields are registry, username, password, and email
 # @section -- Docker configurations
 dockerCredentials: {}
-# Example: 
+# Example:
 #   registry: docker.io
 #   username: dockerhubusername
 #   password: dockerhubpassword
@@ -325,6 +325,9 @@ notebooks:
     value: |
       ml.config.enableProjects = true;
       ml.config.enableNotebooks = true;
+  # -- A list of environment variables that may need to be added to MapLarge for a Notebook deployment
+  # @section -- Notebook configurations
+  environmentVariables: []
 
 ## Database preload configurations
 # -- preloadMLData.enabled Enables MapLarge to preload data from a remote docker image


### PR DESCRIPTION
Updates the statefulset to perform a check if `.Values.notebooks.environmentVariables` exists before  templating. Resolves the issue of a failed template when no env vars are included. Also sets a default empty array for `.Values.notebooks.environmentVariables`

Closes #8 