### PR TITLE
Simplify how notebooks are enabled and js.js is templated

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,5 +3,5 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.2.4
+version: 3.2.5
 appVersion: "maplarge"

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.2.4](https://img.shields.io/badge/Version-3.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.2.5](https://img.shields.io/badge/Version-3.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 
@@ -148,8 +148,6 @@ $ helm install maplarge maplarge -f custom.values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | notebooks.enabled | bool | `false` | Enables MapLarge Notebooks and creates the necessary Service Account, Role and RoleBinding |
-| notebooks.environmentVariables | list | `[]` | A list of environment variables that may need to be added to MapLarge for a Notebook deployment |
-| notebooks.jsjs | object | `{"value":"ml.config.enableProjects = true;\nml.config.enableNotebooks = true;\n"}` | A list of Notebook specific js.js configurations to add to the default js.js |
 
 ### Deployment Resources
 

--- a/charts/maplarge/templates/_helpers.tpl
+++ b/charts/maplarge/templates/_helpers.tpl
@@ -200,13 +200,15 @@ is true or default otherwise.
 Builds the js.js based on the inputs from the values if Notebooks are enabled.
 */}}
 {{- define "maplarge.jsjs" }}
-  {{- if and (.Values.notebooks.enabled) (.Values.jsjs.value) }}
-  {{- printf "%s%s" .Values.jsjs.value  .Values.notebooks.jsjs.value }}
-  {{- else if and (.Values.notebooks.jsjs.enabled) (not .Values.jsjs.value) -}}
-  {{- printf "%s" .Values.notebooks.jsjs.value }}
-  {{- else if and (.Values.jsjs.value) (not .Values.notebooks.enabled) }}
-  {{- printf "%s" .Values.jsjs.value }}
+  {{- $jsjs := "" -}}
+  {{- $nJsjs := "" -}}
+  {{- if .Values.jsjs.value -}}
+  {{- $jsjs = cat .Values.jsjs.value "\n" }}
   {{- end }}
+  {{- if .Values.notebooks.enabled }}
+  {{- $nJsjs = "ml.config.enableNotebooks = true;"}}
+  {{- end }}
+  {{- printf "%s%s" $jsjs $nJsjs}}
 {{- end }}
 
 {{/*

--- a/charts/maplarge/templates/configmap.yaml
+++ b/charts/maplarge/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   {{- if .Values.authPlugin.enabled }}
   {{ .Values.authPlugin.filename }}: {{ toJson .Values.authPlugin.config | quote }}
   {{- end }}
-  {{- if or (.Values.jsjs.value) (and .Values.notebooks.enabled .Values.notebooks.jsjs.value) }}
+  {{- if or .Values.jsjs.value .Values.notebooks.enabled }}
   js.js: {{ include "maplarge.jsjs" .  | quote }}
   {{- end }}
   {{- if .Values.interClusterConfigJson}}

--- a/charts/maplarge/templates/statefulset.yaml
+++ b/charts/maplarge/templates/statefulset.yaml
@@ -130,9 +130,6 @@ spec:
           {{- if .Values.extraEnvironmentVariables }}
           {{- (toYaml .Values.extraEnvironmentVariables | nindent 10) }}
           {{- end }}
-          {{- if and .Values.notebooks.enabled .Values.notebooks.environmentVariables }}
-          {{- (toYaml .Values.notebooks.environmentVariables | nindent 10) }}
-          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -197,7 +194,9 @@ spec:
             subPath: _maplarge_license.lic
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
-          {{- tpl (default "" .Values.extraVolumeMounts) $ | nindent 10 }}
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -290,7 +289,9 @@ spec:
             secretName: {{ include "maplarge.licenseName" . }}
         {{- end }}
         {{- if .Values.extraVolumes }}
-        {{- tpl (default "" .Values.extraVolumes) $ | nindent 8 }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
   updateStrategy:
     type: {{ .Values.updateStrategyType | quote }}

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -129,7 +129,7 @@ extraLabels: {}
 # @section -- General
 extraVolumes: []
 # Example:
-#   extraVolumes: |
+#   extraVolumes:
 #   - name: extra-config
 #     configMap:
 #       name: test-config-map
@@ -138,7 +138,7 @@ extraVolumes: []
 # @section -- General
 extraVolumeMounts: []
 # Example:
-#   extraVolumeMounts: |
+#   extraVolumeMounts:
 #   - mountPath: /maplarge/
 #     name: extra-config
 #     subPath: ml-config.extra.yaml
@@ -319,15 +319,6 @@ notebooks:
   # -- Enables MapLarge Notebooks and creates the necessary Service Account, Role and RoleBinding
   # @section -- Notebook configurations
   enabled: false
-  # -- A list of Notebook specific js.js configurations to add to the default js.js
-  # @section -- Notebook configurations
-  jsjs:
-    value: |
-      ml.config.enableProjects = true;
-      ml.config.enableNotebooks = true;
-  # -- A list of environment variables that may need to be added to MapLarge for a Notebook deployment
-  # @section -- Notebook configurations
-  environmentVariables: []
 
 ## Database preload configurations
 # -- preloadMLData.enabled Enables MapLarge to preload data from a remote docker image


### PR DESCRIPTION
- Simplifies enabling notebooks.
  - the `js.js` is automatically added if `notebooks.enabled = true`
  - removed extra env var section. Users can place these in the `environmentVariables` seciton
- Cleaned up the `extraVolumes` and `extraVolumeMounts` templating

Closes #17 