### PR TITLE
Match the application labels and podAffinity labels

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,7 +3,7 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.3.0
+version: 3.3.1
 appVersion: "maplarge"
 maintainers:
   - name: MapLarge DevOps

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 

--- a/charts/maplarge/templates/statefulset.yaml
+++ b/charts/maplarge/templates/statefulset.yaml
@@ -256,7 +256,7 @@ spec:
                 - key: "application"
                   operator: In
                   values:
-                  - {{ include "maplarge.fullname" . | quote }}
+                  - {{ .Release.Name | quote }}
             topologyKey: "kubernetes.io/hostname"
       {{- else if .Values.preferNodeAntiAffinity }}
         podAntiAffinity:
@@ -268,7 +268,7 @@ spec:
                 - key: "application"
                   operator: In
                   values:
-                  - {{ include "maplarge.fullname" . | quote }}
+                  -{{ .Release.Name | quote }}
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       {{- end }}


### PR DESCRIPTION
The values used for the `application` label is different in the labels section and the podAntiAffinity checks.

Closes #21