### PR TITLE
Fix bug where truncated label could end in illegal character _

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,7 +3,7 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.5.0
+version: 3.5.1
 appVersion: "maplarge"
 maintainers:
   - name: MapLarge DevOps

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 

--- a/charts/maplarge/templates/_helpers.tpl
+++ b/charts/maplarge/templates/_helpers.tpl
@@ -1,11 +1,14 @@
 {{/* vim: set filetype=mustache: */}}
 
+{{- define "dnsSafeTruncate" -}}
+{{- print . | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+{{- end}}
+
 {{/*
 This is the "name" of the Chart that is used by other templates in this chart to form a qualified name for the application. By default, this is the name of the Chart; can be overriden via `.Values.nameOverride`
 */}}
-
 {{- define "maplarge.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+{{- include "dnsSafeTruncate" (default .Chart.Name .Values.nameOverride ) }}
 {{- end }}
 
 {{/*
@@ -16,13 +19,13 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "maplarge.fullname" -}}
   {{- if .Values.fullnameOverride }}
-    {{- .Values.fullnameOverride | trunc 52 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." | lower }}
+    {{- include "dnsSafeTruncate" (.Values.fullnameOverride | trunc 52 | lower) }}
   {{- else }}
     {{- $name := default .Chart.Name .Values.nameOverride }}
     {{- if contains $name .Release.Name }}
-      {{- .Release.Name | trunc 52 | trimSuffix "-"  | trimSuffix "_" | trimSuffix "." | lower }}
+      {{- include "dnsSafeTruncate" (.Release.Name | trunc 52 | lower) }}
     {{- else }}
-      {{- printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." | lower }}
+      {{- include "dnsSafeTruncate" (printf "%s-%s" .Release.Name $name | trunc 52 | lower) }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -30,9 +33,8 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-
 {{- define "maplarge.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+{{- include "dnsSafeTruncate" (printf "%s-%s" .Chart.Name .Chart.Version) }}
 {{- end }}
 
 {{/*
@@ -40,7 +42,7 @@ The tag for MapLarge API Server
 */}}
 
 {{- define "maplarge.image" -}}
-{{- default "4.5.0" .Values.image.tag | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+{{- include "dnsSafeTruncate" (default "4.5.0" .Values.image.tag) }}
 {{- end }}
 
 {{/*
@@ -70,7 +72,7 @@ Removed app name from selector labels because now the app name is not going to b
 */}}
 
 {{- define "maplarge.selectorLabels" -}}
-  app.kubernetes.io/instance: {{ .Release.Name | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+  app.kubernetes.io/instance: {{ include "dnsSafeTruncate" (.Release.Name) }}
 {{- end }}
 
 {{/*
@@ -115,7 +117,7 @@ Max length for a DNS subdomain name is 253
 {{- $name := "" -}}
 {{- if gt $totalLen 253 -}}
   {{- $toTrunc := sub $fullnameLen $balencerLen | int -}}
-  {{- $name = include "maplarge.fullname" . | trunc $toTrunc | trimSuffix "-" | trimSuffix "_" | trimSuffix "." -}}
+  {{- $name = include "dnsSafeTruncate" (include "maplarge.fullname" . | trunc $toTrunc ) -}}
 {{- else -}}
   {{- $name = include "maplarge.fullname" . -}}
 {{- end -}}

--- a/charts/maplarge/templates/_helpers.tpl
+++ b/charts/maplarge/templates/_helpers.tpl
@@ -5,7 +5,7 @@ This is the "name" of the Chart that is used by other templates in this chart to
 */}}
 
 {{- define "maplarge.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
 {{- end }}
 
 {{/*
@@ -16,13 +16,13 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "maplarge.fullname" -}}
   {{- if .Values.fullnameOverride }}
-    {{- .Values.fullnameOverride | trunc 52 | trimSuffix "-" | trimSuffix "." | lower }}
+    {{- .Values.fullnameOverride | trunc 52 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." | lower }}
   {{- else }}
     {{- $name := default .Chart.Name .Values.nameOverride }}
     {{- if contains $name .Release.Name }}
-      {{- .Release.Name | trunc 52 | trimSuffix "-"  | trimSuffix "." | lower }}
+      {{- .Release.Name | trunc 52 | trimSuffix "-"  | trimSuffix "_" | trimSuffix "." | lower }}
     {{- else }}
-      {{- printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-" | trimSuffix "." | lower }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." | lower }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -32,7 +32,7 @@ Create chart name and version as used by the chart label.
 */}}
 
 {{- define "maplarge.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
 {{- end }}
 
 {{/*
@@ -40,7 +40,7 @@ The tag for MapLarge API Server
 */}}
 
 {{- define "maplarge.image" -}}
-{{- default "4.5.0" .Values.image.tag | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+{{- default "4.5.0" .Values.image.tag | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
 {{- end }}
 
 {{/*
@@ -70,7 +70,7 @@ Removed app name from selector labels because now the app name is not going to b
 */}}
 
 {{- define "maplarge.selectorLabels" -}}
-  app.kubernetes.io/instance: {{ .Release.Name | trimSuffix "-" | trimSuffix "." }}
+  app.kubernetes.io/instance: {{ .Release.Name | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
 {{- end }}
 
 {{/*
@@ -115,7 +115,7 @@ Max length for a DNS subdomain name is 253
 {{- $name := "" -}}
 {{- if gt $totalLen 253 -}}
   {{- $toTrunc := sub $fullnameLen $balencerLen | int -}}
-  {{- $name = include "maplarge.fullname" . | trunc $toTrunc | trimSuffix "-" | trimSuffix "." -}}
+  {{- $name = include "maplarge.fullname" . | trunc $toTrunc | trimSuffix "-" | trimSuffix "_" | trimSuffix "." -}}
 {{- else -}}
   {{- $name = include "maplarge.fullname" . -}}
 {{- end -}}

--- a/charts/maplarge/templates/_helpers.tpl
+++ b/charts/maplarge/templates/_helpers.tpl
@@ -1,5 +1,8 @@
 {{/* vim: set filetype=mustache: */}}
 
+{{/*
+Helper function to modify a passed in string to a valid DNS domain segment (required for many Kubernetes fields, including label values)
+*/}}
 {{- define "dnsSafeTruncate" -}}
 {{- print . | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
 {{- end}}


### PR DESCRIPTION
Fix bug when truncating user values for Kube resource labels that could end in “_”, which is not allowed