### PR TITLE
Update ingress to be less prescriptive on the class and annotations

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,7 +3,7 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.5.1
+version: 3.5.2
 appVersion: "maplarge"
 maintainers:
   - name: MapLarge DevOps

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
+![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: maplarge](https://img.shields.io/badge/AppVersion-maplarge-informational?style=flat-square)
 
 ## Additional Information
 
@@ -102,8 +102,8 @@ $ helm install maplarge maplarge -f custom.values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | hostnameOverride | string | `nil` | Rarely there is a time when you need to set the MapLarge hostname to something other than the ingress hostname, but if you do have that scenario, you can provide a hostname here to override the value that will be derived from the ingress.hosts[0].basehostname. Note, this does not modify the ingress hostname value. |
-| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"2000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"30","nginx.ingress.kubernetes.io/proxy-read-timeout":"600","nginx.ingress.kubernetes.io/proxy-send-timeout":"600"}` | Annotations to set on the ingress object |
-| ingress.class | string | `"nginx-internal"` | Ingress class to use |
+| ingress.annotations | object | `{}` | Annotations to set on the ingress object. No annotations are set by default; add any ingress controller-specific annotations here as needed. |
+| ingress.class | string | `""` | Ingress class to use. If not set, no ingressClassName will be set on the resource. |
 | ingress.enabled | bool | `true` | Enable ingress object |
 | ingress.hosts[0] | object | `{"baseHostname":"customer-a.dev.maplarge.net","prefixes":8,"tls":{"enabled":true,"secretName":"wildcard-dev-maplarge-net-tls-secret"}}` | Custom DNS name where MapLarge can be reached |
 | ingress.hosts[0].prefixes | int | `8` | The number of dns prefixes to create |

--- a/charts/maplarge/templates/ingress.yaml
+++ b/charts/maplarge/templates/ingress.yaml
@@ -3,6 +3,7 @@
 {{- $fullName := include "maplarge.fullname" . -}}
 {{- $ingressName := include "maplarge.ingressName" . -}}
 {{- $loadBalancerServiceName := include "maplarge.balancerServiceName" . -}}
+{{- $pathType := .Values.ingress.pathType | default "Prefix" -}}
 {{ $policyHost := include "maplarge.hostname" . }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -17,7 +18,9 @@ metadata:
   {{- end }}
 spec:
 {{- with .Values.ingress }}
+  {{- if .class }}
   ingressClassName: {{ .class }}
+  {{- end }}
 {{- range .hosts }}
 {{- if .tls.enabled }}
   tls:
@@ -38,7 +41,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Prefix
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $loadBalancerServiceName }}
@@ -50,7 +53,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Prefix
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $loadBalancerServiceName }}

--- a/charts/maplarge/templates/ingress.yaml
+++ b/charts/maplarge/templates/ingress.yaml
@@ -3,7 +3,6 @@
 {{- $fullName := include "maplarge.fullname" . -}}
 {{- $ingressName := include "maplarge.ingressName" . -}}
 {{- $loadBalancerServiceName := include "maplarge.balancerServiceName" . -}}
-{{- $pathType := .Values.ingress.pathType | default "Prefix" -}}
 {{ $policyHost := include "maplarge.hostname" . }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -41,7 +40,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: {{ $pathType }}
+            pathType: Prefix
             backend:
               service:
                 name: {{ $loadBalancerServiceName }}
@@ -53,7 +52,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: {{ $pathType }}
+            pathType: Prefix
             backend:
               service:
                 name: {{ $loadBalancerServiceName }}

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -382,16 +382,16 @@ ingress:
   # -- Enable ingress object
   # @section -- Ingress Configuration
   enabled: true
-  # -- Ingress class to use
+  # -- Ingress class to use. If not set, no ingressClassName will be set on the resource.
   # @section -- Ingress Configuration
-  class: nginx-internal
-  # -- Annotations to set on the ingress object
+  class: ""
+  # -- Path type for ingress rules. One of Prefix, Exact, or ImplementationSpecific.
   # @section -- Ingress Configuration
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: 2000m
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+  pathType: Prefix
+  # -- Annotations to set on the ingress object. No annotations are set by default;
+  # add any ingress controller-specific annotations here as needed.
+  # @section -- Ingress Configuration
+  annotations: {}
   hosts:
     # Usually you only need one host here, but this is an array field and accepts multiple values.
     # -- Custom DNS name where MapLarge can be reached

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -385,9 +385,6 @@ ingress:
   # -- Ingress class to use. If not set, no ingressClassName will be set on the resource.
   # @section -- Ingress Configuration
   class: ""
-  # -- Path type for ingress rules. One of Prefix, Exact, or ImplementationSpecific.
-  # @section -- Ingress Configuration
-  pathType: Prefix
   # -- Annotations to set on the ingress object. No annotations are set by default;
   # add any ingress controller-specific annotations here as needed.
   # @section -- Ingress Configuration


### PR DESCRIPTION
Updates our ingress object and values to remove the default class and annotations we were using.

Closes several PRs to related to the ingress object: #10 #28 #33  #25