### PR TITLE
Use named port instead of numeric for service's target port

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,8 +3,8 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.6.1
-appVersion: "3.6.1"
+version: 3.6.2
+appVersion: "3.6.2"
 maintainers:
   - name: MapLarge DevOps
     email: maplarge.devops@maplarge.com

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.1](https://img.shields.io/badge/AppVersion-3.6.1-informational?style=flat-square)
+![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.2](https://img.shields.io/badge/AppVersion-3.6.2-informational?style=flat-square)
 
 ## Additional Information
 

--- a/charts/maplarge/templates/headlessservice.yaml
+++ b/charts/maplarge/templates/headlessservice.yaml
@@ -19,7 +19,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - port: 80
-      targetPort: {{ default "80" .Values.service.targetPort }}
+      targetPort: http
       protocol: TCP
       name: web
   selector:

--- a/charts/maplarge/templates/loadbalancerservice.yaml
+++ b/charts/maplarge/templates/loadbalancerservice.yaml
@@ -17,7 +17,8 @@ spec:
   sessionAffinity: None
   ports:
     - port: 80
-      targetPort: {{ default "80" .Values.service.targetPort }}
+      targetPort: http
       protocol: TCP
+      name: web
   selector:
     {{- include "maplarge.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
One fewer place we need to configure the specific listening port of the container