### PR TITLE
Make it possible to disable preUpgradeHook job if necessary

### DIFF
--- a/charts/maplarge/Chart.yaml
+++ b/charts/maplarge/Chart.yaml
@@ -3,8 +3,8 @@ name: maplarge
 description: MapLarge Kubernetes Helm Chart
 kubeVersion: ">= 1.19.0-0"
 type: application
-version: 3.6.2
-appVersion: "3.6.2"
+version: 3.6.3
+appVersion: "3.6.3"
 maintainers:
   - name: MapLarge DevOps
     email: maplarge.devops@maplarge.com

--- a/charts/maplarge/README.md
+++ b/charts/maplarge/README.md
@@ -2,7 +2,7 @@
 
 MapLarge Kubernetes Helm Chart
 
-![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.2](https://img.shields.io/badge/AppVersion-3.6.2-informational?style=flat-square)
+![Version: 3.6.3](https://img.shields.io/badge/Version-3.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.3](https://img.shields.io/badge/AppVersion-3.6.3-informational?style=flat-square)
 
 ## Additional Information
 
@@ -93,7 +93,7 @@ $ helm install maplarge maplarge -f custom.values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| hooks.preUpgradeHook | object | `{"image":{"repository":"bitnami/kubectl","tag":"latest"}}` | Enables pre-upgrade hook to ensure proper upgrade procedure for DB binary format revisions |
+| hooks.preUpgradeHook | object | `{"enabled":true,"image":{"repository":"bitnami/kubectl","tag":"latest"}}` | Enables pre-upgrade hook to ensure proper upgrade procedure for DB binary format revisions |
 | hooks.preUpgradeHook.image.repository | string | `"bitnami/kubectl"` | The image repository to use for the pre-upgrade hook job |
 | hooks.preUpgradeHook.image.tag | string | `"latest"` | The image tag to use for the pre-upgrade hook job. |
 

--- a/charts/maplarge/templates/hooks/pre-upgrade-job.yaml
+++ b/charts/maplarge/templates/hooks/pre-upgrade-job.yaml
@@ -1,4 +1,4 @@
-{{- if gt (.Values.replicas | int) 1}}
+{{- if and (.Values.hooks.preUpgradeHook.enabled) (gt (.Values.replicas | int) 1) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/maplarge/templates/hooks/pre-upgrade-rbac.yaml
+++ b/charts/maplarge/templates/hooks/pre-upgrade-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if gt (.Values.replicas | int) 1}}
+{{- if and (.Values.hooks.preUpgradeHook.enabled) (gt (.Values.replicas | int) 1) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/maplarge/values.yaml
+++ b/charts/maplarge/values.yaml
@@ -409,6 +409,7 @@ hooks:
   # -- Enables pre-upgrade hook to ensure proper upgrade procedure for DB binary format revisions
   # @section -- Hooks
   preUpgradeHook:
+    enabled: true
     image:
       # -- The image repository to use for the pre-upgrade hook job
       # @section -- Hooks


### PR DESCRIPTION
In cases where we are not allowed to pull down `bitnami/kubectl:latest` (or similar), it is preferable to disable the upgrade hook than to have it fail