### PR TITLE
Lower case the repo owner name so the OCI build works

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Package and push charts
         run: |
+          # OCI repository names must be lowercase; the GitHub org is "MapLarge"
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
           for chart in charts/*/; do
             CHART_NAME=$(basename "$chart")
             CHART_VERSION=$(yq '.version' "$chart/Chart.yaml")
@@ -75,5 +77,5 @@ jobs:
             helm package "$chart"
 
             echo "Pushing to GHCR"
-            helm push "${CHART_NAME}-${CHART_VERSION}.tgz" oci://ghcr.io/${{ github.repository_owner }}/charts
+            helm push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/${OWNER}/charts"
           done


### PR DESCRIPTION
ghcr.io image paths must be in lowercase. Our org name has two capitals so we must lowercase for the OCI artifact to publish correctly.